### PR TITLE
fix/window.gtag is not defined for Next.js-hydration event

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     },
   },
   rules: {
+    'react/no-danger': 'off',
     'react/prop-types': 'off',
     'react/react-in-jsx-scope': 'off',
     'react/jsx-no-target-blank': 2,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ yarn add next-gtag
 ```
 
 ## Usage
-in `pages/_app.js`:
+`pages/_app.js`:
 ```tsx
 import { NextGtag } from "next-gtag";
 
@@ -40,6 +40,25 @@ function MyApp({ Component, pageProps }) {
 }
 
 export default MyApp;
+```
+
+`pages/_document.js`:
+```tsx
+import { Html, Head, Main, NextScript } from 'next/document'
+import { gtagScript } from "next-gtag";
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+      <Main />
+      <NextScript />
+      {gtagScript}
+      </body>
+    </Html>
+  )
+}
 ```
 
 Then, gtag tracking will be added to your page. 🥳

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { default as NextGtag, NextGtagProps } from './NextGtag'
-export { gtagEvent, EventOptions } from './utils'
+export { gtagEvent, EventOptions, gtagScript } from './utils'

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export interface EventOptions {
   value: number
   category?: string
@@ -16,3 +18,15 @@ export const gtagEvent = (
     non_interaction: nonInteraction,
   })
 }
+
+export const gtagScript = (
+  <script
+    dangerouslySetInnerHTML={{
+      __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+          `,
+    }}
+  />
+)


### PR DESCRIPTION
refs https://github.com/vercel/next.js/commit/bebf3725a83f59b3c07635f985fe6cec368c1b0b

adding `gtagScript` for _document.js